### PR TITLE
Chore: upgrade `date-fns` to 4 with `timezonesupport`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "test:coverage": "jest --config ./config/jest.config.js --coverage"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.1.2",
     "@react-google-maps/api": "^2.20.3",
     "@reduxjs/toolkit": "^2.3.0",
-    "date-fns": "^3.6.0",
-    "date-fns-tz": "^3.1.3",
+    "date-fns": "^4.1.0",
     "joi": "^17.13.3",
     "mongodb": "^6.9.0",
     "next": "^14.2.15",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@date-fns/tz": "^1.1.2",
+    "@photostructure/tz-lookup": "^11.0.0",
     "@react-google-maps/api": "^2.20.3",
     "@reduxjs/toolkit": "^2.3.0",
     "date-fns": "^4.1.0",
@@ -23,8 +24,7 @@
     "react-icons": "^5.3.0",
     "react-redux": "^9.1.2",
     "redux-thunk": "^3.1.0",
-    "swr": "^2.2.5",
-    "tz-lookup": "^6.1.25"
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.9",
@@ -35,7 +35,6 @@
     "@types/node": "20.14.12",
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.1",
-    "@types/tz-lookup": "^6.1.2",
     "autoprefixer": "^10.4.20",
     "eslint": "8.56.0",
     "eslint-config-next": "^14.2.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@react-google-maps/api':
         specifier: ^2.20.3
         version: 2.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15,11 +18,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0(react-redux@9.1.2(@types/react@18.3.11)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
-      date-fns-tz:
-        specifier: ^3.1.3
-        version: 3.2.0(date-fns@3.6.0)
+        specifier: ^4.1.0
+        version: 4.1.0
       joi:
         specifier: ^17.13.3
         version: 17.13.3
@@ -306,6 +306,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@date-fns/tz@1.1.2':
+    resolution: {integrity: sha512-Xmg2cPmOPQieCLAdf62KtFPU9y7wbQDq1OAzrs/bEQFvhtCPXDiks1CHDE/sTXReRfh/MICVkw/vY6OANHUGiA==}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -1254,13 +1257,8 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
-  date-fns-tz@3.2.0:
-    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
-
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3456,6 +3454,8 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@date-fns/tz@1.1.2': {}
+
   '@emnapi/runtime@1.3.1':
     dependencies:
       tslib: 2.8.0
@@ -4565,11 +4565,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
-  date-fns-tz@3.2.0(date-fns@3.6.0):
-    dependencies:
-      date-fns: 3.6.0
-
-  date-fns@3.6.0: {}
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@date-fns/tz':
         specifier: ^1.1.2
         version: 1.1.2
+      '@photostructure/tz-lookup':
+        specifier: ^11.0.0
+        version: 11.0.0
       '@react-google-maps/api':
         specifier: ^2.20.3
         version: 2.20.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -47,9 +50,6 @@ importers:
       swr:
         specifier: ^2.2.5
         version: 2.2.5(react@18.3.1)
-      tz-lookup:
-        specifier: ^6.1.25
-        version: 6.1.25
     devDependencies:
       '@tailwindcss/forms':
         specifier: ^0.5.9
@@ -75,9 +75,6 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
-      '@types/tz-lookup':
-        specifier: ^6.1.2
-        version: 6.1.2
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -636,6 +633,9 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@photostructure/tz-lookup@11.0.0':
+    resolution: {integrity: sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -793,9 +793,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/tz-lookup@6.1.2':
-    resolution: {integrity: sha512-9y31Xf/8FHXrCHjvVjGZLcsayAa6ABNc8bZlk6MPOQLLlr41tICSqW3TRPRIx2nodbzdKs5N7ipHWBrUsWUiAA==}
 
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
@@ -3092,9 +3089,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  tz-lookup@6.1.25:
-    resolution: {integrity: sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==}
-
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
@@ -3833,6 +3827,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@photostructure/tz-lookup@11.0.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4006,8 +4002,6 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/tz-lookup@6.1.2': {}
 
   '@types/use-sync-external-store@0.0.3': {}
 
@@ -6770,8 +6764,6 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typescript@5.6.3: {}
-
-  tz-lookup@6.1.25: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/src/utilities/getUtcOffset.ts
+++ b/src/utilities/getUtcOffset.ts
@@ -1,10 +1,10 @@
-import { getTimezoneOffset } from 'date-fns-tz'
+import { tzOffset } from '@date-fns/tz'
 import tzLookup from 'tz-lookup'
 
 export function getUtcOffset(latitude: number, longitude: number): number {
   const timezone = tzLookup(latitude, longitude)
   const now = new Date()
-  const offset = getTimezoneOffset(timezone, now) / 60000
+  const offset = tzOffset(timezone, now)
 
   return offset
 }

--- a/src/utilities/getUtcOffset.ts
+++ b/src/utilities/getUtcOffset.ts
@@ -1,5 +1,5 @@
 import { tzOffset } from '@date-fns/tz'
-import tzLookup from 'tz-lookup'
+import tzLookup from "@photostructure/tz-lookup"
 
 export function getUtcOffset(latitude: number, longitude: number): number {
   const timezone = tzLookup(latitude, longitude)


### PR DESCRIPTION
## Description
Date-fns has upgraded to version 4, and added a timezone support. 
in this case we do not have to request 3rd party packages, and can use date-fns solutions
I also decided to get rid of `tz-lookup` since it was deleted from the github. and was updated last time 5 years ago

## What I have done
- I have upgraded `date-fns` to version 4
- I have replaced 3rd party `date-fns-tz` with the `@date-fns/tz`
- I have replaced outdated `tz-lookip` with the `@photostructure/tz-lookup`

## How to verify

## Checklist

- [ ] All new and existing unit tests pass.
- [ ] No new dependencies were installed.
- [ ] No changes to the core functionality were made.
- [ ] Removed any debugging or unnecessary code.
